### PR TITLE
Use ActiveScreen endpoint to get screen UUID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "wc-grab"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap 2.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbus 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wc-grab"
 description = "Screen shot taker for Way Cooler"
-version = "0.1.0"
+version = "0.2.0"
 license = "MIT"
 repository = "https://github.com/way-cooler/way-cooler-grab/"
 keywords = ["Wayland"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,17 +72,14 @@ fn resolution(con: &Connection) -> (u32, u32) {
     let screens_msg = Message::new_method_call("org.way-cooler",
                                                "/org/way_cooler/Screen",
                                                "org.way_cooler.Screen",
-                                               "List")
+                                               "ActiveScreen")
     .expect("Could not construct message -- is Way Cooler running?");
     let screen_r = con.send_with_reply_and_block(screens_msg, WAIT_TIME)
         .expect("Could not talk to Way Cooler -- is Way Cooler running?");
     let screen_r = &screen_r.get_items()[0];
     let output_id = match screen_r {
-        &MessageItem::Array(ref items, _) => {
-            match items[0] {
-                MessageItem::Str(ref string) => string.clone(),
-                _ => panic!("Array didn't contain output id")
-            }
+        &MessageItem::Str(ref string) => {
+            string.clone()
         }
         _ => panic!("Wrong type from Screen")
     };


### PR DESCRIPTION
Combined with [this way-cooler pr](https://github.com/way-cooler/way-cooler/pull/350) fixes it so that we take the picture of the active output, instead of randomly selecting the output (but usually the first).